### PR TITLE
Update context and error handling documentation: Refined references t…

### DIFF
--- a/backend/hook-development.md
+++ b/backend/hook-development.md
@@ -515,7 +515,7 @@ if ($ctx.$body.name) {
 - **Use $throw Methods**: Use `$ctx.$throw['400']()` instead of `throw new Error()` for consistent error handling
 - **HTTP Status Codes**: Use numeric methods like `$ctx.$throw['404']()` for standard HTTP errors
 - **Semantic Errors**: Use descriptive methods like `$ctx.$throw.businessLogic()` for business logic errors
-- **Error Recovery**: Check `$ctx.$error` in afterHook to handle errors gracefully
+- **Error Recovery**: Check `$ctx.$api.error` in afterHook to handle errors gracefully (only available in afterHook)
 - **Descriptive Messages**: Provide clear error messages and details for debugging
 - **Graceful Fallbacks**: Handle cases where expected data might be missing
 

--- a/frontend/custom-handlers.md
+++ b/frontend/custom-handlers.md
@@ -269,7 +269,7 @@ return {
 - **Use $throw Methods**: Use `$ctx.$throw['400']()` instead of `throw new Error()` for consistent error handling
 - **HTTP Status Codes**: Use numeric methods like `$ctx.$throw['404']()` for standard HTTP errors
 - **Semantic Errors**: Use descriptive methods like `$ctx.$throw.businessLogic()` for business logic errors
-- **Error Recovery**: Check `$ctx.$error` in afterHook to handle errors gracefully
+- **Error Recovery**: Check `$ctx.$api.error` in afterHook to handle errors gracefully (only available in afterHook)
 - **Descriptive Messages**: Provide clear error messages and details for debugging
 - **Status Codes**: Errors automatically return appropriate HTTP status codes
 


### PR DESCRIPTION
…o $ctx.$error, replacing it with $ctx.$api.error for clarity in afterHook scenarios. Added new sections detailing API request/response information and usage examples to enhance understanding of error handling and logging practices.